### PR TITLE
ci(playwright): speed up E2E by using Playwright container + preinstalled browsers

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Run ESLint
         run: npm run lint
@@ -61,6 +65,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Run unit tests
         run: npm test
@@ -118,6 +124,9 @@ jobs:
     name: End-to-End Tests
     runs-on: ubuntu-latest
     needs: [test, docker]
+    container:
+      image: mcr.microsoft.com/playwright:v1.40.0-jammy
+      options: --ipc=host
     
     services:
       mongodb:
@@ -138,8 +147,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
 
       - name: Start application
         run: |
@@ -147,7 +154,7 @@ jobs:
           sleep 10
         env:
           NODE_ENV: test
-          MONGODB_URI: mongodb://localhost:27017/datablog-e2e
+          MONGODB_URI: mongodb://mongodb:27017/datablog-e2e
 
       - name: Run Playwright tests
         run: npx playwright test


### PR DESCRIPTION
Optimize E2E job by running in the official Playwright container so browsers are preinstalled, and avoid redundant downloads.\n\nKey changes:\n- Use container: mcr.microsoft.com/playwright:v1.40.0-jammy (preinstalled Chromium/Firefox/WebKit).\n- Remove explicit `npx playwright install --with-deps`.\n- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` for npm ci in all jobs.\n- Use `--ipc=host` to improve Chromium stability in CI.\n- Point app to MongoDB service hostname (`mongodb`) when running inside the container.\n\nBenefits:\n- Faster job startup (skip browser installs).\n- More reliable runs due to stable, known-good browser versions.\n- Clearer CI config focused on Playwright best practices.