### PR TITLE
Potential fix for code scanning alert no. 64: Syntax error

### DIFF
--- a/.github/workflows/zap-cli.yml
+++ b/.github/workflows/zap-cli.yml
@@ -27,13 +27,13 @@ jobs:
               cp .env.example .env
             else
               printf "%s\n" \
-DD_SITE=datadoghq.com \
-DD_API_KEY=DUMMY \
-DD_CLIENT_TOKEN=dummy \
-DD_APPLICATION_ID=dummy \
-DD_SERVICE=datablog \
-DD_ENV=ci \
-DD_VERSION=2.0.0 > .env
+                DD_SITE=datadoghq.com \
+                DD_API_KEY=DUMMY \
+                DD_CLIENT_TOKEN=dummy \
+                DD_APPLICATION_ID=dummy \
+                DD_SERVICE=datablog \
+                DD_ENV=ci \
+                DD_VERSION=2.0.0 > .env
             fi
           fi
 


### PR DESCRIPTION
Potential fix for [https://github.com/petems/datadog-rum-apm-e2e-example/security/code-scanning/64](https://github.com/petems/datadog-rum-apm-e2e-example/security/code-scanning/64)

The best way to fix the problem is to avoid ambiguity between YAML and shell syntax. Within a `run: |` block in GitHub Actions, multi-line shell scripts should use proper indentation and avoid any syntax that could introduce parsing errors for YAML linters. Instead of using heredoc (`cat > .env <<'EOF' ... EOF`) directly in the YAML, replace it with an inline echo with escaped newlines or use `printf`. Alternatively, indent the heredoc in a way that will not confuse YAML parsers, or split multiline commands into several echo lines. 

The single best, simplest fix is: 
- Replace the heredoc (`cat > .env <<'EOF' ... EOF`) with either a multi-line `echo` command or a correctly indented heredoc that is safe for YAML parsing.
- Ensure the block under `run: |` is correctly indented and structured for both YAML and the shell.

Edit lines 29-37 of `.github/workflows/zap-cli.yml` to replace the heredoc with a safe printf approach.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
