### PR TITLE
Potential fix for code scanning alert no. 63: Syntax error

### DIFF
--- a/.github/workflows/nikto.yml
+++ b/.github/workflows/nikto.yml
@@ -23,7 +23,7 @@ jobs:
             if [ -f .env.example ]; then
               cp .env.example .env
             else
-              cat > .env <<'EOF'
+              cat > .env <<EOF
 DD_SITE=datadoghq.com
 DD_API_KEY=DUMMY
 DD_CLIENT_TOKEN=dummy


### PR DESCRIPTION
Potential fix for [https://github.com/petems/datadog-rum-apm-e2e-example/security/code-scanning/63](https://github.com/petems/datadog-rum-apm-e2e-example/security/code-scanning/63)

The best way to fix the problem is to remove the single quotes from the heredoc delimiter in the shell script inside the YAML workflow. Specifically, on line 26, change `cat > .env <<'EOF'` to `cat > .env <<EOF`. This change eliminates the use of embedded single quotes, which confuse the YAML parser within multi-line (`|`) blocks. This fix retains the workflow’s functionality (writing environment variables to a `.env` file if needed) while making the YAML file syntactically correct and parseable. No other parts of the file need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
