### PR TITLE
fix(security): hide Express X-Powered-By header

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,9 @@ const crypto = require('crypto');
 
 const app = express();
 
+// Hide implementation details from response headers
+app.disable('x-powered-by');
+
 // View engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');

--- a/test/securityHeaders.test.js
+++ b/test/securityHeaders.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+
+describe('Security headers', () => {
+  let app;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    app = require('../app');
+  });
+
+  it('does not expose X-Powered-By header', async () => {
+    const res = await request(app).get('/');
+    expect(res.headers['x-powered-by']).toBeUndefined();
+  });
+
+  it('sets key security headers via Helmet', async () => {
+    const res = await request(app).get('/');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['x-frame-options']).toBeDefined();
+    expect(res.headers['content-security-policy']).toBeDefined();
+  });
+});

--- a/test/securityHeaders.test.js
+++ b/test/securityHeaders.test.js
@@ -2,19 +2,19 @@ const request = require('supertest');
 
 describe('Security headers', () => {
   let app;
+  let res;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     process.env.NODE_ENV = 'test';
     app = require('../app');
+    res = await request(app).get('/');
   });
 
-  it('does not expose X-Powered-By header', async () => {
-    const res = await request(app).get('/');
+  it('does not expose X-Powered-By header', () => {
     expect(res.headers['x-powered-by']).toBeUndefined();
   });
 
-  it('sets key security headers via Helmet', async () => {
-    const res = await request(app).get('/');
+  it('sets key security headers via Helmet', () => {
     expect(res.headers['x-content-type-options']).toBe('nosniff');
     expect(res.headers['x-frame-options']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();


### PR DESCRIPTION
Summary
Disable the Express `X-Powered-By` header to avoid information disclosure flagged by Nikto/CodeQL.

Motivation
Reduces fingerprinting of the framework and addresses security scan findings.

Changes
- Add `app.disable('x-powered-by')` in `app.js`
- Add `test/securityHeaders.test.js` to assert header absent and key Helmet headers present

Tests
- Unit: passing (`npm test`), added coverage for headers.

Breaking changes
None

Checklist
- [x] Conventional Commit title
- [x] Tests added and passing
- [x] Lint/format clean
