### PR TITLE
fix(ci): prevent ZAP duplicate issues and fix artifacts

### DIFF
--- a/.github/workflows/zap-cli.yml
+++ b/.github/workflows/zap-cli.yml
@@ -57,6 +57,8 @@ jobs:
           # Only create/update issues on pushes to main/master to avoid duplicates
           allow_issue_writing: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
           issue_title: 'ZAP Baseline Report'
+          # Use a unique, v4-safe artifact name (alnum, underscore, dot)
+          artifact_name: "zap_scan_${{ github.run_id }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           cmd_options: '-a'
 

--- a/.github/workflows/zap-cli.yml
+++ b/.github/workflows/zap-cli.yml
@@ -50,7 +50,7 @@ jobs:
             if curl -sf http://localhost:3000 >/dev/null; then echo "app up"; break; fi; sleep 2; done
 
       - name: ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.12.0
+        uses: zaproxy/action-baseline@v0.14.0
         with:
           target: 'http://localhost:3000'
           rules_file_name: '.zap/rules.tsv'

--- a/.github/workflows/zap-cli.yml
+++ b/.github/workflows/zap-cli.yml
@@ -62,6 +62,19 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           cmd_options: '-a'
 
+      - name: Upload ZAP artifacts (fallback)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap_scan_${{ github.run_id }}_fallback
+          if-no-files-found: ignore
+          path: |
+            **/zap*.zip
+            **/zap*.html
+            **/zap*.md
+            **/zap*.xml
+            **/zap*.json
+
       - name: Stop stack
         if: always()
         run: |

--- a/.github/workflows/zap-cli.yml
+++ b/.github/workflows/zap-cli.yml
@@ -57,7 +57,6 @@ jobs:
           # Only create/update issues on pushes to main/master to avoid duplicates
           allow_issue_writing: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
           issue_title: 'ZAP Baseline Report'
-          artifact_name: 'zap-baseline-report'
           token: ${{ secrets.GITHUB_TOKEN }}
           cmd_options: '-a'
 

--- a/.github/workflows/zap-cli.yml
+++ b/.github/workflows/zap-cli.yml
@@ -6,11 +6,16 @@ on:
   pull_request:
     branches: [ master, main ]
 
+concurrency:
+  group: zap-baseline-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zap:
     name: OWASP ZAP Baseline
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: read
       issues: write
       security-events: write
@@ -49,8 +54,10 @@ jobs:
         with:
           target: 'http://localhost:3000'
           rules_file_name: '.zap/rules.tsv'
-          # Allow creating/updating issues for pushes and same-repo PRs only
-          allow_issue_writing: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+          # Only create/update issues on pushes to main/master to avoid duplicates
+          allow_issue_writing: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
+          issue_title: 'ZAP Baseline Report'
+          artifact_name: 'zap-baseline-report'
           token: ${{ secrets.GITHUB_TOKEN }}
           cmd_options: '-a'
 


### PR DESCRIPTION
Summary
Prevent ZAP GitHub Action from creating duplicate issues and ensure artifacts upload consistently.

Motivation
The ZAP workflow was creating duplicate issues (push + PR) and artifacts weren’t uploaded reliably. This aligns the workflow with best practices and repository conventions.

Changes
- Restrict issue creation to pushes on `main`/`master` only (no PR issues)
- Add workflow concurrency to cancel parallel runs per ref
- Grant `actions: write` permission to enable artifact upload
- Set explicit `artifact_name` and `issue_title` for consistency

Tests
- Manual verification recommended: run ZAP on a PR (no issue created) and on `main` (single issue updated/created). Confirm artifact `zap-baseline-report` appears in the run.

Breaking changes
None

Linked issues
Refs https://github.com/petems/datadog-rum-apm-e2e-example/actions/runs/17366702225/job/49294678530

Checklist
- [x] Conventional Commit title
- [x] Lint/format unaffected (workflow change only)
- [x] CI workflow updated
