### PR TITLE
ci(security): ensure SARIF uploads and add scan summaries

### DIFF
--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -17,13 +17,88 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Run njsscan
+      - name: Run njsscan (SARIF + missing-controls)
         uses: ajinabraham/njsscan-action@v7
         with:
-          args: "--sarif --output njsscan.sarif ."
+          args: "--sarif --output njsscan.sarif --missing-controls ."
 
-      - name: Upload SARIF to code scanning
+      - name: Run njsscan (JSON)
+        if: always()
+        uses: ajinabraham/njsscan-action@v7
+        with:
+          args: "--json --output njsscan.json --missing-controls ."
+
+      - name: Run njsscan (HTML)
+        if: always()
+        uses: ajinabraham/njsscan-action@v7
+        with:
+          args: "--html --output njsscan-report.html --missing-controls ."
+
+      - name: Ensure SARIF exists (njsscan)
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f njsscan.sarif ]; then
+            printf '%s\n' \
+              '{' \
+              '  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",' \
+              '  "version": "2.1.0",' \
+              '  "runs": [' \
+              '    {' \
+              '      "tool": { "driver": { "name": "njsscan" } },' \
+              '      "results": []' \
+              '    }' \
+              '  ]' \
+              '}' > njsscan.sarif
+          fi
+
+      - name: Upload SARIF (njsscan)
+        if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: njsscan.sarif
 
+      - name: Summarize njsscan findings
+        if: always()
+        shell: bash
+        run: |
+          json_count() {
+            jq -r '.findings // .results // [] | length' "$1" 2>/dev/null || echo 0
+          }
+
+          sarif_total() {
+            jq '[.runs[]?.results[]] | length' "$1" 2>/dev/null || echo 0
+          }
+
+          top_rules() {
+            jq -r '[.runs[]?.results[]?.ruleId] | group_by(.) | map({rule: .[0], count: length}) | sort_by(-.count) | .[:5]' "$1" 2>/dev/null || echo '[]'
+          }
+
+          if command -v jq >/dev/null 2>&1; then
+            TOTAL=$(sarif_total njsscan.sarif)
+            TOP=$(top_rules njsscan.sarif)
+          else
+            TOTAL=unknown
+            TOP='[]'
+          fi
+
+          echo "### njsscan Static Analysis" >> "$GITHUB_STEP_SUMMARY"
+          echo "SARIF: njsscan.sarif" >> "$GITHUB_STEP_SUMMARY"
+          echo "JSON: njsscan.json" >> "$GITHUB_STEP_SUMMARY"
+          echo "HTML: njsscan-report.html" >> "$GITHUB_STEP_SUMMARY"
+          echo "Findings total: ${TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Top rules (ruleId:count):" >> "$GITHUB_STEP_SUMMARY"
+          if command -v jq >/dev/null 2>&1; then
+            echo "$TOP" | jq -r '.[] | "- \(.rule): \(.count)"' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload njsscan artifacts (JSON/HTML)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: njsscan-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+          path: |
+            njsscan.json
+            njsscan-report.html

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -112,10 +112,44 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
           ignore-unfixed: true
 
+      - name: Ensure SARIF file exists (trivy)
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f trivy-results.sarif ]; then
+            printf '%s\n' \
+              '{' \
+              '  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",' \
+              '  "version": "2.1.0",' \
+              '  "runs": [' \
+              '    {' \
+              '      "tool": { "driver": { "name": "trivy" } },' \
+              '      "results": []' \
+              '    }' \
+              '  ]' \
+              '}' > trivy-results.sarif
+          fi
+
       - name: Upload Trivy scan results
+        if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Summarize Trivy findings
+        if: always()
+        shell: bash
+        run: |
+          if command -v jq >/dev/null 2>&1; then
+            COUNT=$(jq '[.runs[]?.results[]] | length' trivy-results.sarif 2>/dev/null || echo 0)
+          else
+            COUNT=unknown
+          fi
+          {
+            echo "### Trivy Scan"
+            echo "SARIF uploaded from: trivy-results.sarif"
+            echo "Findings count: ${COUNT}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Hadolint (Dockerfile linting)
         uses: hadolint/hadolint-action@v3.1.0
@@ -125,10 +159,44 @@ jobs:
           output-file: hadolint-results.sarif
           failure-threshold: error
 
+      - name: Ensure SARIF file exists (hadolint)
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f hadolint-results.sarif ]; then
+            printf '%s\n' \
+              '{' \
+              '  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",' \
+              '  "version": "2.1.0",' \
+              '  "runs": [' \
+              '    {' \
+              '      "tool": { "driver": { "name": "hadolint" } },' \
+              '      "results": []' \
+              '    }' \
+              '  ]' \
+              '}' > hadolint-results.sarif
+          fi
+
       - name: Upload Hadolint scan results
+        if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: hadolint-results.sarif
+
+      - name: Summarize Hadolint findings
+        if: always()
+        shell: bash
+        run: |
+          if command -v jq >/dev/null 2>&1; then
+            COUNT=$(jq '[.runs[]?.results[]] | length' hadolint-results.sarif 2>/dev/null || echo 0)
+          else
+            COUNT=unknown
+          fi
+          {
+            echo "### Hadolint"
+            echo "SARIF uploaded from: hadolint-results.sarif"
+            echo "Findings count: ${COUNT}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # End-to-End Tests with Playwright
   e2e:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,7 +25,41 @@ jobs:
             zricethezav/gitleaks:latest \
             detect --source /repo --report-format sarif --report-path /repo/gitleaks.sarif --redact
 
-      - name: Upload SARIF
+      - name: Ensure SARIF exists (gitleaks)
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f gitleaks.sarif ]; then
+            printf '%s\n' \
+              '{' \
+              '  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",' \
+              '  "version": "2.1.0",' \
+              '  "runs": [' \
+              '    {' \
+              '      "tool": { "driver": { "name": "gitleaks" } },' \
+              '      "results": []' \
+              '    }' \
+              '  ]' \
+              '}' > gitleaks.sarif
+          fi
+
+      - name: Upload SARIF (gitleaks)
+        if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: gitleaks.sarif
+
+      - name: Summarize gitleaks findings
+        if: always()
+        shell: bash
+        run: |
+          if command -v jq >/dev/null 2>&1; then
+            COUNT=$(jq '[.runs[]?.results[]] | length' gitleaks.sarif 2>/dev/null || echo 0)
+          else
+            COUNT=unknown
+          fi
+          {
+            echo "### Gitleaks Secret Scan"
+            echo "SARIF uploaded from: gitleaks.sarif"
+            echo "Findings count: ${COUNT}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Summary
Ensure security scans always upload SARIF and provide context when failing.

Motivation
Runs were failing without SARIF artifacts or useful context. Upload steps only ran on success and some tools didn’t emit SARIF on crash, leaving no diagnostics. This makes code scanning and triage difficult.

Changes
- Guard SARIF creation with placeholder files when scanners crash/skip
- Upload SARIF with `if: always()` for gitleaks, njsscan, trivy, hadolint
- Add GITHUB_STEP_SUMMARY with finding counts and (njsscan) top rule IDs
- Produce njsscan JSON/HTML artifacts for deeper analysis

Screenshots
None (workflow changes only).

Tests
- Verified workflow syntax. Summary steps and artifacts should appear on next run.

Breaking changes
None

Linked issues
Refs #18

Checklist
- [x] Follows branch naming conventions
- [x] Conventional Commit title
- [x] Lint/format clean
- [x] Tests unaffected
