### PR TITLE
fix(pages): accept content field in page creation

### DIFF
--- a/controllers/manage-pages.js
+++ b/controllers/manage-pages.js
@@ -45,17 +45,22 @@ let createPage = async (body, user) => {
     throw new Error('User authentication required to create pages');
   }
 
+  const pageBody = body.body || body.content;
+  if (!body.title || !pageBody) {
+    throw new Error('Title and content are required');
+  }
+
   // Setup Manual Tracing using await tracer.trace
   const id = await tracer.trace('manage-pages.getNextPageId', async () => {
     return await getNextPageId();
   });
   const result = await tracer.trace('manage-pages.savePage', async () => {
-    return await savePage(id, body.title, body.body, user.id);
+    return await savePage(id, body.title, pageBody, user.id);
   });
 
   // Original without Tracing
   //let id = await getNextPageId();
-  //let result = await savePage(id, body.title, body.body, user.id);
+  //let result = await savePage(id, body.title, pageBody, user.id);
 
   return result;
 };

--- a/controllers/manage-pages.test.js
+++ b/controllers/manage-pages.test.js
@@ -277,6 +277,22 @@ describe('manage-pages controller', () => {
       );
     });
 
+    it('should accept content field when creating a page', async () => {
+      const body = { title: 'Alt Page', content: 'Alt Content' };
+
+      const result = await createPage(body, mockUser);
+
+      expect(pageModel).toHaveBeenCalledWith({
+        id: 6,
+        title: 'Alt Page',
+        body: 'Alt Content',
+        author: mockUser.id,
+        createdDate: expect.any(Number),
+        updatedDate: expect.any(Number),
+      });
+      expect(result.save).toHaveBeenCalled();
+    });
+
     it('should throw error when user is not provided', async () => {
       const body = { title: 'New Page', body: 'New Content' };
 


### PR DESCRIPTION
Summary
Adds support for using a `content` field when creating pages and validates required fields.

Motivation
Client requests used `content` instead of `body`, causing page creation to fail.

Changes
- handle `content` or `body` in `createPage`
- require title and content before saving
- test coverage for `content` field usage

Screenshots
None

Tests
- Unit: `npm run test:coverage`
- Lint: `npm run lint`
- Format: `npm run format:check`

Breaking changes
None

Linked issues
None

Checklist
- [ ] Follows branch naming conventions
- [x] Conventional Commit title
- [x] Tests added/updated and passing (`npm run test:coverage`)
- [x] Lint/format clean (`npm run lint && npm run format:check`)
- [ ] Screenshots updated (if UI)

------
https://chatgpt.com/codex/tasks/task_e_68be2e7a36e483218ac1debb898011b8