### PR TITLE
ci(e2e): fix node version in workflow

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.18.0'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -210,7 +210,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.18.0'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
Summary
Use latest Node 22 release for lint and e2e jobs so Playwright tests can run.

Motivation
Node 22.18.0 is not published, causing setup-node to fail and the e2e workflow to abort.

Changes
- configure setup-node to install Node 22 in lint and e2e jobs

Screenshots
None

Tests
- Unit: `npm test` *(fails: requires running MongoDB)*
- E2E: not run

Breaking changes
None

Linked issues
None

Checklist
- [ ] Follows branch naming conventions
- [ ] Conventional Commit title
- [ ] Tests added/updated and passing (`npm run test:coverage`)
- [x] Lint/format clean (`npm run lint && npm run format:check`)
- [ ] Screenshots updated (if UI)


------
https://chatgpt.com/codex/tasks/task_e_68be3536344c832195975c12653ef7ae