### PR TITLE
test: mock mongoose models with mockingoose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Related docs: see `README.md` and `docs/DEVELOPMENT.md` for workflows, commands,
 ## Testing Guidelines
 
 - Frameworks: Jest (unit/integration) and Playwright (E2E).
+- Use mockingoose to stub Mongoose models so unit tests run without MongoDB.
 - Naming: `*.test.js` next to code or at repo root (e.g., `app.test.js`).
 - Before PRs: run `npm run test:coverage`; aim to maintain or increase coverage.
 - E2E rely on `playwright.config.js`; ensure app is running or use Playwright's server config.


### PR DESCRIPTION
Summary
- replace manual Mongoose model mocks with mockingoose so unit tests run without MongoDB
- document mockingoose usage in testing guidelines

Motivation
Avoids requiring a live MongoDB instance for unit tests and standardizes mocking.

Changes
- swap jest mocks for mockingoose in page controller and auth route tests
- update AGENTS.md testing section with mockingoose guidance

Tests
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`

Breaking changes
None

Linked issues

Checklist
- [x] Follows branch naming conventions
- [x] Conventional Commit title
- [x] Tests added/updated and passing (`npm run test:coverage`)
- [x] Lint/format clean (`npm run lint && npm run format:check`)
- [ ] Screenshots updated (if UI)


------
https://chatgpt.com/codex/tasks/task_e_68be375b06c48321a004fcef835a0c01